### PR TITLE
Fix CI gofmt check to target actual Go files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Go lint
         run: |
-          if [ $(gofmt -l src/* | wc -l) -gt 0 ]; then
-            gofmt -d src/*
+          if [ $(gofmt -l *.go | wc -l) -gt 0 ]; then
+            gofmt -d *.go
             exit 1
           fi
 


### PR DESCRIPTION
The gofmt lint step ran `gofmt -l src/*`, but this repo has no src/ directory, so the check silently matched nothing and never caught formatting issues.